### PR TITLE
Move download code out of commands.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- portable `download_zips` function for downloading raw data from USDA
+
+- download functionality for 2022 files
+
+### Fixed
+
+- CLI download utility can handle specific years ([#20](https://github.com/stactools-packages/usda-cdl/issues/20))
+
 ## [0.1.3] - 2023-02-28
 
-## Added
+### Added
 
 - A license link ([#18](https://github.com/stactools-packages/usda-cdl/pull/18))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- portable `download_zips` function for downloading raw data from USDA
-
-- download functionality for 2022 files
+-`download_zips` function for downloading raw data from USDA ([#22](https://github.com/stactools-packages/usda-cdl/pull/22))
+- Download functionality for 2022 files ([#22](https://github.com/stactools-packages/usda-cdl/pull/22))
 
 ### Fixed
 
-- CLI download utility can handle specific years ([#20](https://github.com/stactools-packages/usda-cdl/issues/20))
+- CLI download utility can handle specific years ([#20](https://github.com/stactools-packages/usda-cdl/pull/22))
 
 ## [0.1.3] - 2023-02-28
 

--- a/src/stactools/usda_cdl/commands.py
+++ b/src/stactools/usda_cdl/commands.py
@@ -81,7 +81,7 @@ def create_usda_cdl_command(cli: Group) -> Command:
             tile.tile_geotiff(infile_as_path, pathlib.Path(str(destination)), size)
 
     @usda_cdl.command("download", short_help="Download zipped source GeoTIFFs")
-    @click.argument("years", nargs=-1)
+    @click.argument("years", nargs=-1, type=int)
     @click.argument("destination", nargs=1)
     def download(years: List[int], destination: Path) -> None:
         """Downloads the USDA CDL zip files to the destination directory. It's a

--- a/src/stactools/usda_cdl/constants.py
+++ b/src/stactools/usda_cdl/constants.py
@@ -325,3 +325,9 @@ EXTENT = Extent(
         ]
     ),
 )
+
+# most recently available year for download
+MOST_RECENT_YEAR = 2022
+
+# first available year for download
+FIRST_AVAILABLE_YEAR = 2008

--- a/src/stactools/usda_cdl/download.py
+++ b/src/stactools/usda_cdl/download.py
@@ -36,7 +36,9 @@ def download_zips(years: List[int], destination: pathlib.Path) -> List[pathlib.P
             )
             # in 2021 they changed the file basename slightly ¯\_(ツ)_/¯
             if year >= 2021:
-                confidence_url = confidence_url.replace("layer", "Layer")
+                confidence_url = confidence_url.replace("layer", "Layer").replace(
+                    "confidence", "Confidence"
+                )
 
             urls.append(confidence_url)
 

--- a/src/stactools/usda_cdl/download.py
+++ b/src/stactools/usda_cdl/download.py
@@ -1,0 +1,75 @@
+import os
+import pathlib
+from typing import List
+
+import requests
+from tqdm import tqdm
+
+from stactools.usda_cdl.constants import FIRST_AVAILABLE_YEAR, MOST_RECENT_YEAR
+
+
+def download_zips(years: List[int], destination: pathlib.Path) -> List[pathlib.Path]:
+    """Download zipped GeoTiffs from USDA
+
+    Args:
+        years: list of years to download
+        destination: destination directory for downloaded files
+
+    Returns: list of filepaths for downloaded zip files
+    """
+    os.makedirs(str(destination), exist_ok=True)
+    if not years:
+        years = list(range(FIRST_AVAILABLE_YEAR, MOST_RECENT_YEAR + 1))
+    urls = list()
+    for year in years:
+        if year < FIRST_AVAILABLE_YEAR or year > MOST_RECENT_YEAR:
+            raise Exception(f"Unsupported CDL year: {year}")
+        urls.append(
+            "https://www.nass.usda.gov/Research_and_Science/Cropland"
+            f"/Release/datasets/{year}_30m_cdls.zip"
+        )
+        # in 2017 and beyond there is a confidence layer available
+        if year >= 2017:
+            confidence_url = (
+                "https://www.nass.usda.gov/Research_and_Science/Cropland"
+                f"/Release/datasets/{year}_30m_confidence_layer.zip"
+            )
+            # in 2021 they changed the file basename slightly ¯\_(ツ)_/¯
+            if year >= 2021:
+                confidence_url = confidence_url.replace("layer", "Layer")
+
+            urls.append(confidence_url)
+
+        # each year, a new version of the cumalative (2008-present) "Cultivated"
+        # and "Crop Frequency" layers are generated
+        if year == MOST_RECENT_YEAR:
+            urls.append(
+                "https://www.nass.usda.gov/Research_and_Science/Cropland"
+                f"/Release/datasets/{MOST_RECENT_YEAR}_Cultivated_Layer.zip"
+            )
+            urls.append(
+                "https://www.nass.usda.gov/Research_and_Science/Cropland"
+                "/Release/datasets/Crop_Frequency_"
+                f"{FIRST_AVAILABLE_YEAR}-{MOST_RECENT_YEAR}.zip"
+            )
+
+    zips = []
+    for url in urls:
+        path = pathlib.Path(str(destination)) / os.path.basename(url)
+        if path.exists():
+            print(f"{path} already exists, skipping...")
+            continue
+        response = requests.get(url, stream=True)
+        with tqdm.wrapattr(
+            open(path, "wb"),
+            "write",
+            miniters=1,
+            desc=url.split("/")[-1],
+            total=int(response.headers.get("content-length", 0)),
+        ) as fout:
+            for chunk in response.iter_content(chunk_size=4096):
+                fout.write(chunk)
+
+        zips.append(path)
+
+    return zips


### PR DESCRIPTION
**Description:**
Thank you so much for your work on this package! It will save me a bunch of time building a STAC collection with the USDA CDL data. While trying to use the package in my own context I found a few small changes that might be useful to you and other users.

1. The download command can't handle the case when you pass a specific year (or years) because the input gets parsed as a string by `click`
2. It would be useful to be able to use the `download` function in non-cli context (e.g. in a python script) so I moved the actual downloading code to a new function `stactools.usda_cdl.download.download_zips`

**Related Issue(s):**
resolves #20 
resolves #21

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Examples have been updated to reflect changes, if applicable
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
